### PR TITLE
Migrate to v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
   
     "name": "zoom auto close",
     "description": "This extension automatically closes tabs left by zoom meeting application.",
@@ -11,9 +11,7 @@
     },
 
     "background": {
-      "scripts": [
-        "background.js"
-      ]
+      "service_worker": "background.js"
     },
 
     "content_scripts": [


### PR DESCRIPTION
## Overview

As you know, Chrome Web Store have already stopped accepting Manifest v2 extensions.
This zoom-auto-close also disappeared. I love this extension so I tried to migrate to v3.
ref: https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/

## Details

- Bump up `manifest_version`
- Replace `background.scripts` to `background.service_worker`

## Tests

- [x] Install the local extension without errors
- [x] Close zoom page successfully